### PR TITLE
fix: work around what we assume is a bug in Axon Framework: when a qu…

### DIFF
--- a/example/src/test/kotlin/io/holixon/axon/gateway/example/JacksonApplicationITest.kt
+++ b/example/src/test/kotlin/io/holixon/axon/gateway/example/JacksonApplicationITest.kt
@@ -1,13 +1,10 @@
 package io.holixon.axon.gateway.example
 
-import org.awaitility.Awaitility
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import java.time.Duration
 import java.util.*
 import kotlin.test.assertNotNull
 
@@ -23,14 +20,15 @@ internal class JacksonApplicationITest {
 
   @Test
   fun `should create and query for request using jackson`() {
-    // create request
+    scenario.createRequest(requestId, revision = 1L)
+
+    assertNotNull(scenario.queryForRequest(requestId, revision = 1L))
+
     Thread {
-      Thread.sleep(2_000)
-      scenario.createRequest(requestId)
+      Thread.sleep(500)
+      scenario.updateRequest(requestId, revision = 2L)
     }.start()
 
-    Awaitility.await("Could not find request for id $requestId").atMost(Duration.ofSeconds(13)).untilAsserted {
-      assertNotNull(scenario.queryForRequest(requestId))
-    }
+    assertNotNull(scenario.queryForRequest(requestId, revision = 2L))
   }
 }

--- a/example/src/test/kotlin/io/holixon/axon/gateway/example/TestScenario.kt
+++ b/example/src/test/kotlin/io/holixon/axon/gateway/example/TestScenario.kt
@@ -16,11 +16,9 @@ internal class TestScenario(
   val commandGateway: CommandGateway,
   val queryGateway: QueryGateway
 ) {
-  companion object : KLogging() {
-    const val revision = 1L
-  }
+  companion object : KLogging()
 
-  fun createRequest(requestId: String = UUID.randomUUID().toString()): String {
+  fun createRequest(requestId: String = UUID.randomUUID().toString(), revision: Long = 1L): String {
     return commandGateway.send<String>(
       GenericCommandMessage.asCommandMessage<CreateApprovalRequestCommand>(
         CreateApprovalRequestCommand(
@@ -37,7 +35,24 @@ internal class TestScenario(
     }
   }
 
-  fun queryForRequest(requestId: String): ApprovalRequest? {
+  fun updateRequest(requestId: String = UUID.randomUUID().toString(), revision: Long = 1L): String {
+    return commandGateway.send<String>(
+      GenericCommandMessage.asCommandMessage<UpdateApprovalRequestCommand>(
+        UpdateApprovalRequestCommand(
+          requestId = requestId,
+          subject = "Subject",
+          currency = "EUR",
+          amount = "43"
+        )
+      ).withMetaData(RevisionValue(revision).toMetaData().apply {
+        logger.info("Sending update command for $requestId with metadata $this")
+      })
+    ).join().let {
+      requestId
+    }
+  }
+
+  fun queryForRequest(requestId: String, revision: Long = 1L): ApprovalRequest? {
     return queryGateway
       .query(
         GenericCommandMessage

--- a/example/src/test/kotlin/io/holixon/axon/gateway/example/XstreamApplicationITest.kt
+++ b/example/src/test/kotlin/io/holixon/axon/gateway/example/XstreamApplicationITest.kt
@@ -1,14 +1,10 @@
 package io.holixon.axon.gateway.example
 
-import org.awaitility.Awaitility
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
-import java.lang.Thread.sleep
-import java.time.Duration
 import java.util.*
 import kotlin.test.assertNotNull
 
@@ -24,14 +20,15 @@ internal class XstreamApplicationITest {
 
   @Test
   fun `should create and query for request using XStream`() {
-    // create request
+    scenario.createRequest(requestId, revision = 1L)
+
+    assertNotNull(scenario.queryForRequest(requestId, revision = 1L))
+
     Thread {
-      sleep(2_000)
-      scenario.createRequest(requestId)
+      Thread.sleep(500)
+      scenario.updateRequest(requestId, revision = 2L)
     }.start()
 
-    Awaitility.await("Could not find request for id $requestId").atMost(Duration.ofSeconds(13)).untilAsserted {
-      assertNotNull(scenario.queryForRequest(requestId))
-    }
+    assertNotNull(scenario.queryForRequest(requestId, revision = 2L))
   }
 }


### PR DESCRIPTION
…ery is canceled without a subscription to the updates Flux being active, the updateHandler is not removed from the QueryUpdateEmitter and we get an error message on the next emitted update because the Sink is already terminated.

Fixes #129